### PR TITLE
Adapt to format changes of yadt-minion pull request #14

### DIFF
--- a/src/integrationtest/python/yadt_status_answer.py
+++ b/src/integrationtest/python/yadt_status_answer.py
@@ -61,11 +61,11 @@ services:
 - frontend-service:
     needs_services: [backend-service]
     state: $frontend_service_state
-    service_artefact: yit-frontend-service
+    service_artefact: [yit-frontend-service]
     toplevel_artefacts: [yit-config-$host]
 - backend-service:
     state: $backend_service_state
-    service_artefact: yit-backend-service
+    service_artefact: [yit-backend-service]
     toplevel_artefacts: [yit-config-$host]
 artefact_names_handled_by_yadt:
 - yit-frontend-service
@@ -108,7 +108,7 @@ defaults:
 services:
 - backend-service:
     state: $backend_service_state
-    service_artefact: yit-backend-service
+    service_artefact: [yit-backend-service]
     needs_services: ['service://foo/bar']
 artefact_names_handled_by_yadt:
 - yit-frontend-service
@@ -150,11 +150,11 @@ services:
 - frontend-service:
     needs_services: [backend-service]
     state: $frontend_service_state
-    service_artefact: yit-frontend-service
+    service_artefact: [yit-frontend-service]
     toplevel_artefacts: [yit-config-$host]
 - backend-service:
     state: $backend_service_state
-    service_artefact: yit-backend-service
+    service_artefact: [yit-backend-service]
     toplevel_artefacts: [yit-config-$host]
     needs_artefacts: [yit-config-$host]
 

--- a/src/unittest/python/components_tests.py
+++ b/src/unittest/python/components_tests.py
@@ -245,4 +245,4 @@ services:
         host.set_attrs_from_data(data)
         self.assertEqual(len(host.services), 1)
         self.assertTrue("backend-service" in host.services)
-        self.assertTrue(host.services["backend-service"]["service_artefact"], "yit-backend-service")
+        self.assertEqual(host.services["backend-service"]["service_artefact"], "yit-backend-service")

--- a/src/unittest/python/components_tests.py
+++ b/src/unittest/python/components_tests.py
@@ -237,7 +237,7 @@ class HostTests(unittest.TestCase):
 services:
 - backend-service:
     state: $backend_service_state
-    service_artefact: yit-backend-service
+    service_artefact: [yit-backend-service]
     needs_services: ['service://foo/bar']
 """
         data = yaml.load(data_text, Loader=yaml.Loader)
@@ -245,4 +245,4 @@ services:
         host.set_attrs_from_data(data)
         self.assertEqual(len(host.services), 1)
         self.assertTrue("backend-service" in host.services)
-        self.assertEqual(host.services["backend-service"]["service_artefact"], "yit-backend-service")
+        self.assertEqual(host.services["backend-service"]["service_artefact"], ["yit-backend-service"])


### PR DESCRIPTION
Pull request #14 in yadt-minion adds Upstart support. This changes the status in the following way:
- init_script is now a list of strings instead of a string
  - this is not used in the integration/unit tests
- service_artefact is now also a list of strings instead of a string
  - format changed in all tests, tests keep running without code changes
